### PR TITLE
Bug fix for stacked bar chart rendering

### DIFF
--- a/lib/charts/renderers/stackedbar_chart_renderer.dart
+++ b/lib/charts/renderers/stackedbar_chart_renderer.dart
@@ -124,6 +124,8 @@ class StackedBarChartRenderer implements ChartRenderer {
 
     var y = 0,
         length = bar.length,
+        // Keeps track of heights of previously graphed bars. If all bars before
+        // current one have 0 height, the current bar doesn't need offset.
         prevZeroHeight = true;
     bar.transition()
         ..attrWithCallback('y', (d, i, c) {
@@ -135,13 +137,14 @@ class StackedBarChartRenderer implements ChartRenderer {
             if (i != 0) {
               // If previous bars has 0 height, don't offset for spacing
               // If any of the previous bar has non 0 height, do the offset.
-              ht -= prevZeroHeight ? 0 :
+              ht -= prevZeroHeight ? 1 :
                 (theme.defaultSeparatorWidth + theme.defaultStrokeWidth);
             } else {
+              // When rendering next group of bars, reset prevZeroHeight.
+              prevZeroHeight = true;
               ht -= 1;  // -1 so bar does not overlap x axis.
             }
             if (ht < 0) ht = 0;
-            //
             prevZeroHeight = (ht == 0) && prevZeroHeight;
             return ht;
           })

--- a/lib/charts/src/chart_area_impl.dart
+++ b/lib/charts/src/chart_area_impl.dart
@@ -341,7 +341,7 @@ class _ChartArea implements ChartArea, ChartAreaEventSource {
 
         // Use default domain if lowest and highest are the same, right now
         // lowest is always 0, change to lowest when we make use of it.
-        if (highest != 0) domain = [0, highest];
+        domain = (highest != 0) ? [0, highest] : [0, 1];
       }
       axis.initAxisDomain(sampleCol, false, domain);
     });
@@ -354,7 +354,7 @@ class _ChartArea implements ChartArea, ChartAreaEventSource {
            domain;
 
        if (sampleColumnSpec.useOrdinalScale) {
-         domain = values.toList();
+         domain = values.map((e) => e.toString()).toList();
        } else {
          var extent = new Extent.items(values);
          domain = [extent.min, extent.max];


### PR DESCRIPTION
- Fix stacked bar chart rendering for bars with 0 height in the same group.
- When "useOridnalScale" is set for a columnspec, force all values to String automatically when constructing the dimension axis.
