### PR TITLE
Small style tweaks to charts package that should not have a runtime

### DIFF
--- a/lib/charts/renderers/stackedbar_chart_renderer.dart
+++ b/lib/charts/renderers/stackedbar_chart_renderer.dart
@@ -72,7 +72,7 @@ class StackedBarChartRenderer extends BaseRenderer {
       ic = i;
     });
 
-    ic = 1e100;
+    ic = 1000000000;
     var enter = bar.enter.append('rect')
       ..classed('bar')
       ..styleWithCallback('fill', (d, i, c) => colorForKey(_reverseIdx(i)))

--- a/lib/charts/renderers/waterfall_chart_renderer.dart
+++ b/lib/charts/renderers/waterfall_chart_renderer.dart
@@ -96,7 +96,7 @@ class WaterfallChartRenderer extends BaseRenderer {
       ic = i;
     });
 
-    ic = 1e100;
+    ic = 1000000000;
     var enter = bar.enter.append('rect')
       ..classed('bar')
       ..styleWithCallback('fill', (d, i, c) => colorForKey(_reverseIdx(i)))

--- a/lib/charts/src/chart_area_impl.dart
+++ b/lib/charts/src/chart_area_impl.dart
@@ -396,7 +396,7 @@ class _ChartArea implements ChartArea {
         var axis = _dimensionAxes[column],
             orientation = dimensionAxisOrientations[index];
         axis.prepareToDraw(orientation, theme.dimensionAxisTheme);
-        layout.axes[orientation] = axis.size;
+        layout._axes[orientation] = axis.size;
       });
     }
 
@@ -408,7 +408,7 @@ class _ChartArea implements ChartArea {
         var axis = _measureAxes[key],
             orientation = measureAxisOrientations[index];
         axis.prepareToDraw(orientation, theme.measureAxisTheme);
-        layout.axes[orientation] = axis.size;
+        layout._axes[orientation] = axis.size;
       });
     }
 
@@ -487,15 +487,16 @@ class _ChartArea implements ChartArea {
     layout.renderArea = new Rect(
         leftAxis.width, topAxis.height, renderAreaWidth, renderAreaHeight);
 
-    layout.axes[ORIENTATION_TOP] =
-        new Rect(leftAxis.width, 0, renderAreaWidth, topAxis.height);
-    layout.axes[ORIENTATION_RIGHT] =
+    layout._axes
+      ..[ORIENTATION_TOP] =
+        new Rect(leftAxis.width, 0, renderAreaWidth, topAxis.height)
+      ..[ORIENTATION_RIGHT] =
         new Rect(leftAxis.width + renderAreaWidth, topAxis.y,
-            rightAxis.width, renderAreaHeight);
-    layout.axes[ORIENTATION_BOTTOM] =
+            rightAxis.width, renderAreaHeight)
+      ..[ORIENTATION_BOTTOM] =
         new Rect(leftAxis.width, topAxis.height + renderAreaHeight,
-            renderAreaWidth, bottomAxis.height);
-    layout.axes[ORIENTATION_LEFT] =
+            renderAreaWidth, bottomAxis.height)
+      ..[ORIENTATION_LEFT] =
         new Rect(leftAxis.width, topAxis.height,
             leftAxis.width, renderAreaHeight);
   }
@@ -508,7 +509,7 @@ class _ChartArea implements ChartArea {
     if (!_pendingLegendUpdate) return;
     if (_config == null || _config.legend == null || _series.isEmpty) return;
 
-    List legend = [];
+    var legend = <ChartLegendItem>[];
     List seriesByColumn =
         new List.generate(data.columns.length, (i) => new List());
 
@@ -596,18 +597,26 @@ class _ChartArea implements ChartArea {
 
 class _ChartAreaLayout implements ChartAreaLayout {
   @override
-  final Map<String, Rect> axes = {
-    ORIENTATION_LEFT: const Rect(),
-    ORIENTATION_RIGHT: const Rect(),
-    ORIENTATION_TOP: const Rect(),
-    ORIENTATION_BOTTOM: const Rect()
-  };
+  final _axes = <String, Rect>{
+        ORIENTATION_LEFT: const Rect(),
+        ORIENTATION_RIGHT: const Rect(),
+        ORIENTATION_TOP: const Rect(),
+        ORIENTATION_BOTTOM: const Rect()
+      };
+
+  UnmodifiableMapView<String, Rect> _axesView;
+
+  get axes => _axesView;
 
   @override
   Rect renderArea;
 
   @override
   Rect chartArea;
+
+  _ChartAreaLayout() {
+    _axesView = new UnmodifiableMapView(_axes);
+  }
 }
 
 class _ChartSeriesInfo {

--- a/lib/charts/src/chart_config_impl.dart
+++ b/lib/charts/src/chart_config_impl.dart
@@ -30,7 +30,7 @@ class _ChartConfig extends ChangeNotifier implements ChartConfig {
   ChartLegend legend;
 
   @override
-  List<String> displayedMeasureAxes;
+  Iterable<String> displayedMeasureAxes;
 
   @override
   bool renderDimensionAxes = true;

--- a/lib/charts/src/chart_data_impl.dart
+++ b/lib/charts/src/chart_data_impl.dart
@@ -26,7 +26,7 @@ class _ChartData extends ChangeNotifier implements ChartData {
     // Create a copy of columns.  We do not currently support
     // changes to the list of columns.  Any changes to the spec
     // will be applied at the next ChartBase.draw();
-    this._columns = new List.from(value);
+    this._columns = new List<ChartColumnSpec>.from(value);
   }
 
   Iterable<ChartColumnSpec> get columns => _columns;

--- a/lib/charts/transformers/aggregation.dart
+++ b/lib/charts/transformers/aggregation.dart
@@ -254,9 +254,9 @@ class AggregationModel {
 
     // Create both when object is created and groupBy is called
     // Reuse dimension enumerations if possible.
-    List<Map> oldDimToInt = _dimToIntMap;
-    _dimToIntMap = new List.generate(_dimFields.length,
-        (i) => i < _dimPrefixLength ? oldDimToInt[i] : new Map());
+    var oldDimToInt = _dimToIntMap;
+    _dimToIntMap = new List<Map<dynamic, int>>.generate(_dimFields.length,
+        (i) => i < _dimPrefixLength ? oldDimToInt[i] : new Map<dynamic, int>());
   }
 
   /**

--- a/lib/charts/transformers/aggregation_transformer.dart
+++ b/lib/charts/transformers/aggregation_transformer.dart
@@ -98,14 +98,14 @@ class AggregationTransformer extends ChangeNotifier
 
     // Process rows.
     rows.clear();
-    var transformedRows = [];
+    var transformedRows = <Iterable>[];
     for (var value in _model.valuesForDimension(_dimensionColumnIndices[0])) {
       _generateAggregatedRow(transformedRows, [value]);
     }
     rows.addAll(transformedRows);
 
     // Process columns.
-    columns = new List.generate(_selectedColumns.length, (index) =>
+    columns = new List<ChartColumnSpec>.generate(_selectedColumns.length, (index) =>
         _data.columns.elementAt(_selectedColumns[index]));
   }
 
@@ -116,7 +116,7 @@ class AggregationTransformer extends ChangeNotifier
    * logic to include itself, just move the expand check around the else clause
    * and always write a row of data whether it's expanded or not.
    */
-  _generateAggregatedRow(List aggregatedRows, List dimensionValues) {
+  _generateAggregatedRow(List<Iterable> aggregatedRows, List dimensionValues) {
     var entity = _model.facts(dimensionValues);
     var dimensionLevel = dimensionValues.length - 1;
     var currentDimValue = dimensionValues.last;

--- a/lib/charts/transformers/transpose_transformer.dart
+++ b/lib/charts/transformers/transpose_transformer.dart
@@ -88,7 +88,7 @@ class TransposeTransformer extends ChangeNotifier
 
     columns.clear();
     rows.clear();
-    rows.addAll(new List.generate(_data.columns.length - 1, (i) => []));
+    rows.addAll(new List<Iterable>.generate(_data.columns.length - 1, (i) => []));
 
     // Populate the transposed rows' data, excluding the label column, visit
     // each value in the original data once.

--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -53,8 +53,8 @@ class Pair<T1, T2> {
 
   const Pair(this.first, this.last);
 
-  bool operator==(Pair other) =>
-      other != null && first == other.first && last == other.last;
+  bool operator==(other) =>
+      other is Pair && first == other.first && last == other.last;
 }
 
 /*

--- a/lib/core/lists.dart
+++ b/lib/core/lists.dart
@@ -91,7 +91,7 @@ class Range extends IterableBase<num> {
   num elementAt(int index) => _range.elementAt(index);
 
   @override
-  Iterator get iterator => _range.iterator;
+  Iterator<num> get iterator => _range.iterator;
 
   static int _integerConversionFactor(num val) {
     int k = 1;

--- a/lib/core/rect.dart
+++ b/lib/core/rect.dart
@@ -19,8 +19,8 @@ class Rect {
   const Rect.size(this.width, this.height) : x = 0, y = 0;
   const Rect.position(this.x, this.y) : width = 0, height = 0;
 
-  bool operator==(Rect other) =>
-      isSameSizeAs(other) && isSamePositionAs(other);
+  bool operator==(other) =>
+      other is Rect && isSameSizeAs(other) && isSamePositionAs(other);
 
   bool isSameSizeAs(Rect other) =>
       other != null && width == other.width && height == other.height;
@@ -49,8 +49,8 @@ class EditableRect implements Rect {
   EditableRect.size(this.width, this.height);
   EditableRect.position(this.x, this.y);
 
-  bool operator==(Rect other) =>
-      isSameSizeAs(other) && isSamePositionAs(other);
+  bool operator==(other) =>
+      other is Rect && isSameSizeAs(other) && isSamePositionAs(other);
 
   bool isSameSizeAs(Rect other) =>
       other != null && width == other.width && height == other.height;

--- a/lib/locale/number_format.dart
+++ b/lib/locale/number_format.dart
@@ -74,22 +74,19 @@ class NumberFormat {
         symbol = match.group(4) != null ? match.group(4) : '',
         zfill = match.group(5),
         width = match.group(6) != null ? int.parse(match.group(6)) : 0,
-        comma = match.group(7),
-        precision = match.group(8),
+        comma = match.group(7) != null,
+        precision = match.group(8) != null ?
+            int.parse(match.group(8).substring(1)) : null,
         type = match.group(9),
         scale = 1,
         prefix = '',
         suffix = '',
         integer = false;
 
-    if (precision != null) {
-      precision = int.parse(precision.substring(1));
-    }
-
     if (zfill != null || fill == '0' && align == '=') {
       zfill = fill = '0';
       align = '=';
-      if (comma != null) {
+      if (comma) {
         width -= ((width - 1) / 4).floor();
       }
     }
@@ -128,7 +125,7 @@ class NumberFormat {
 
     NumberFormatFunction formatFunction = _getFormatFunction(type);
 
-    var zcomma = (zfill != null) && (comma != null);
+    var zcomma = (zfill != null) && comma;
 
     return (value) {
       var fullSuffix = suffix;
@@ -172,7 +169,7 @@ class NumberFormat {
 
       // If the fill character is not '0', grouping is applied before
       //padding.
-      if (zfill == null && comma != null) {
+      if (zfill == null && comma) {
         before = formatGroup(before);
       }
 

--- a/lib/locale/time_scale.dart
+++ b/lib/locale/time_scale.dart
@@ -121,8 +121,7 @@ class TimeScale extends LinearScale {
   TimeScale copy() => new TimeScale(domain, range, interpolator, clamp);
 
   List niceInterval(var interval, [int skip = 1]) {
-    var extent = scaleExtent(domain);
-    extent = new Extent(extent[0], extent[1]);
+    var extent = _scaleDomainExtent();
 
     var method = interval == null ? _tickMethod(extent, 10) :
                  interval is int ? _tickMethod(extent, interval) : null;
@@ -166,9 +165,13 @@ class TimeScale extends LinearScale {
     domain = niceInterval(ticks);
   }
 
-  List ticksInterval(var interval, [int skip = 1]) {
+  Extent _scaleDomainExtent() {
     var extent = scaleExtent(domain);
-    extent = new Extent(extent[0], extent[1]);
+    return new Extent(extent[0], extent[1]);
+  }
+
+  List ticksInterval(var interval, [int skip = 1]) {
+    var extent = _scaleDomainExtent();
     var method = interval == null ? _tickMethod(extent, 10) :
         interval is int ? _tickMethod(extent, interval) :
         [interval, skip];

--- a/lib/selection/selection_impl.dart
+++ b/lib/selection/selection_impl.dart
@@ -43,7 +43,7 @@ class _SelectionImpl implements Selection {
           c.querySelectorAll(selector);
     }
 
-    var tmpGroups = new List(),
+    var tmpGroups = new List<SelectionGroup>(),
         index = 0;
     if (source != null) {
       scope = source.scope;
@@ -82,7 +82,7 @@ class _SelectionImpl implements Selection {
 
     if (source != null) {
       scope = source.scope;
-      groups = new List.generate(source.groups.length, (gi) {
+      groups = new List<SelectionGroup>.generate(source.groups.length, (gi) {
         SelectionGroup g = source.groups.elementAt(gi);
         return new _SelectionGroupImpl(
             new List.generate(g.elements.length, (ei) {
@@ -100,7 +100,7 @@ class _SelectionImpl implements Selection {
         }), parent: g.parent);
       });
     } else {
-      groups = new List.generate(1,
+      groups = new List<SelectionGroup>.generate(1,
           (_) => new _SelectionGroupImpl(new List.generate(1,
               (_) => fn(null, 0, null), growable: false)), growable: false);
     }
@@ -115,7 +115,7 @@ class _SelectionImpl implements Selection {
    * be part of the same group, with [SelectionScope.root] as the group's parent
    */
   _SelectionImpl.elements(Iterable elements, SelectionScope this.scope) {
-    groups = new List()..add(new _SelectionGroupImpl(elements));
+    groups = new List<SelectionGroup>()..add(new _SelectionGroupImpl(elements));
   }
 
   /**
@@ -227,10 +227,10 @@ class _SelectionImpl implements Selection {
         v == false ? e.classes.remove(name) : e.classes.add(name));
   }
 
-  void style(String property, String val, {String priority}) {
+  void style(String property, val, {String priority}) {
     assert(property != null && property.isNotEmpty);
     styleWithCallback(property,
-        toCallback(val), priority: priority);
+        toCallback(val as String), priority: priority);
   }
 
   void styleWithCallback(String property,
@@ -538,7 +538,7 @@ class _EnterSelectionImpl implements EnterSelection {
 class _ExitSelectionImpl extends _SelectionImpl implements ExitSelection {
   final DataSelection update;
   _ExitSelectionImpl(Iterable groups, DataSelection update)
-      :super.selectionGroups(groups, update.scope), update = update;
+      : update = update, super.selectionGroups(groups, update.scope);
 }
 
 class _SelectionGroupImpl implements SelectionGroup {

--- a/lib/svg/svg.dart
+++ b/lib/svg/svg.dart
@@ -30,5 +30,5 @@ abstract class SvgPathGenerator {
    * and the element [e].  This method follows the same signature as the
    * other callbacks used by selection API - [ChartedCallback<String>]
    */
-  String path(d, num i, Element e);
+  String path(d, int i, Element e);
 }

--- a/lib/svg/svg_line.dart
+++ b/lib/svg/svg_line.dart
@@ -73,10 +73,10 @@ class SvgLine implements SvgPathGenerator {
    * Get Svg path description for the given [data], element index [index]
    * and element [e] to which the data is associated.
    */
-  String path(List data, int index, Element e) {
+  String path(data, int index, Element e) {
     var segments = [],
         points = [];
-
+    assert(data is List);
     data.asMap().forEach((int i, d) {
       if (defined(d, i, e)) {
         points.add(new math.Point(xAccessor(d, i), yAccessor(d, i)));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: charted
-version: 0.0.8
+version: 0.0.9
 authors:
 - Prasad Sunkari <prsd@google.com>
 - Michael Cheng <midoringo@google.com>

--- a/test/svg/svg_arc_test.dart
+++ b/test/svg/svg_arc_test.dart
@@ -25,7 +25,7 @@ testSvgArc() {
       'correctly interpolates two SvgArcData', () {
     InterpolateFn arcInterpolator =
         interpolateSvgArcData(mockSvgData[5], mockSvgData[6]);
-    for (var i = 0; i <= 1; i += 0.2) {
+    for (var i = 0.0; i <= 1.0; i += 0.2) {
       SvgArcData arcData = arcInterpolator(i);
       expect(arcData.startAngle, closeTo(mockSvgData[5].startAngle * (1 - i) +
           mockSvgData[6].startAngle * i, EPSILON));


### PR DESCRIPTION
impact. Make implementation classes match the type signatures of base
classes. Add a few generic types that weren't specified. Cleanup cases
where a double was used as an index. Move super calls to end of
constructor initialization list matching the Dart style guide.
https://www.dartlang.org/articles/style-guide/#do-place-the-super-call-last-in-a-constructor-initialization-list
Moved version from 0.0.8 to 0.0.9 as badly behaved users that depended on
axes being mutable even though the signature was mutable could be broken.