### PR TITLE
added ability to expand 3-digit hex color code into equivalent 6-digit h...

### DIFF
--- a/lib/core/color.dart
+++ b/lib/core/color.dart
@@ -29,6 +29,10 @@ class Color {
     if (hex.startsWith('#')) {
       hex = hex.substring(1);
     }
+    if (hex.length == 3) {
+      // expand to 6-digit hex code
+      hex = hex[0]*2 + hex[1]*2 + hex[2]*2;
+    }
     rgb.add(int.parse(hex.substring(0, 2), radix: 16));
     rgb.add(int.parse(hex.substring(2, 4), radix: 16));
     rgb.add(int.parse(hex.substring(4, 6), radix: 16));


### PR DESCRIPTION
Possible fix for bug #35 "charted.core.Color._hexToRgb doesn't handle short representation." Tested and working in Chromium 38.0.2125.0

I'm trying to think if there's a method that uses fewer string allocations.  Also, should either this function or Color.fromHex check to ensure that the hex code given is either 3 or 6 chars long?