### PR TITLE
Image path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Charted provides
 * An interactive demo 
 
 ## Screenshot of Charted interactive demo
-![Screenshot of Charted interactive demo](charted-demo-screenshot.png)
+![Screenshot of Charted interactive demo](https://raw.githubusercontent.com/google/charted/master/charted-demo-screenshot.png)
 
 ## Get started with the interactive demo
 Get started with Charted by trying out the interactive demo provided with the package. Follow these instructions and get it running locally on your machine (Git and the Dart SDK has to be installed first):


### PR DESCRIPTION
Right now the screenshot does not show up on pub:
https://pub.dartlang.org/packages/charted

I think this is because the image use a relative path that worked on Github but not on pub.dartlang.org. This pull requests changes so we use the absolute path to the image on Github's servers.

The same technique is used by the "bwu_sparkline" pub package, see polymer image in the top of the readme uses the same type of absolute path:
https://pub.dartlang.org/packages/bwu_sparkline
https://raw.githubusercontent.com/bwu-dart/bwu_sparkline/master/README.md