### PR TITLE
- Bug fix on linear scale nicing the domain too many times.  The nice…

### DIFF
--- a/lib/core/scales.dart
+++ b/lib/core/scales.dart
@@ -145,7 +145,8 @@ abstract class ScaleUtils {
 
   static RoundingFunctions niceStep(num step) => (step > 0)
       ? new RoundingFunctions(
-          (x) => (x / step).floor() * step, (x) => (x / step).ceil() * step)
+          (x) => (x < step) ? x.floor() : (x / step).floor() * step,
+          (x) => (x < step) ? x.ceil() : (x / step).ceil() * step)
       : new RoundingFunctions.identity();
 
   /// Returns a Function that given a value x on the domain, returns the

--- a/lib/core/scales/linear_scale.dart
+++ b/lib/core/scales/linear_scale.dart
@@ -34,7 +34,7 @@ class LinearScale implements Scale {
     _reset();
   }
 
-  void _reset() {
+  void _reset({bool nice: false}) {
     if (nice) {
       _domain = ScaleUtils.nice(
           _domain, ScaleUtils.niceStep(_linearTickRange().step));
@@ -65,7 +65,7 @@ class LinearScale implements Scale {
   @override
   set domain(Iterable value) {
     _domain = value;
-    _reset();
+    _reset(nice: _nice);
   }
 
   @override
@@ -115,7 +115,7 @@ class LinearScale implements Scale {
     assert(value != null);
     if (value != null && _nice != value) {
       _nice = value;
-      _reset();
+      _reset(nice: _nice);
     }
   }
 


### PR DESCRIPTION
… function should only be called when domain or nice is set.  The _reset()  was calling nice each time anything changes in the scale which would cause a domain will all values between 0 and 1 be eventaully niced to a domain of [0, 5] which is very bad for ploting percentages in the renderer.

- Changed nice function's rounding function to only apply the step when the value is greater than or equal to the number of steps, so we don't end up creating a scale that is much larger than the data values when the values are small.