### PR TITLE
Fix for issue 143 - When the values of measures in a series is all th…

### DIFF
--- a/lib/charts/src/cartesian_area_impl.dart
+++ b/lib/charts/src/cartesian_area_impl.dart
@@ -391,7 +391,9 @@ class DefaultCartesianAreaImpl implements CartesianArea {
         // lowest is always 0 unless it is less than 0 - change to lowest when
         // we make use of it.
         domain = highest == lowest
-            ? [0, 1]
+            ? (highest == 0
+                ? [0, 1]
+                : (highest < 0 ? [highest, 0] : [0, highest]))
             : (lowest <= 0 ? [lowest, highest] : [0, highest]);
       }
       axis.initAxisDomain(sampleCol, false, domain);


### PR DESCRIPTION
…e same, the axis initializes the domain of the scale to be [0, 1].  This should either be [lowest, 0] or [0, heighest] base on whether the value is greater or smaller than 0.