### PR TITLE
Fixed null span error

### DIFF
--- a/lib/core/scales/linear_scale.dart
+++ b/lib/core/scales/linear_scale.dart
@@ -135,10 +135,10 @@ class LinearScale implements Scale {
     if (extent == null) {
       extent = ScaleUtils.extent(_domain);
     }
-    var span = extent.max - extent.min,
-        step =
-            math.pow(10, (math.log(span / _ticksCount) / math.LN10).floor()),
-        err = _ticksCount / span * step;
+    var span = extent.max - extent.min;
+    if (span == 0) span = 1.0; // [span / _ticksCount] should never be equal zero.
+    var step = math.pow(10, (math.log(span / _ticksCount) / math.LN10).floor());
+    var err = _ticksCount / span * step;
 
     // Filter ticks to get closer to the desired count.
     if (err <= .15) {


### PR DESCRIPTION
It's a not good solution but I haven't deep vision of the project. So may be you know better solution. It will be great if you give me more advices and your thoughts about this.

So, problem description. If your ChartsData got only 1 value or all values of line is same value like examples bellow, charted library can't display it because of exception of 'can't call floor method of Infinity or NaN'. In `LinearScale` class there is domain, it's a min and max values in scale. In method `_linearTickRange` we calculate `span` and `step`. So, if domain's min and max same, span is 0 and there is exception in step's calculations.

Examples of datas:

1. Empty or just one value
time1, 0

2. Same value over all data
time1, 12, 12
time2, 12, 12
time3, 12, 12