### PR TITLE
- Change the signature of the line chart renderer's position proximit…

### DIFF
--- a/lib/charts/cartesian_renderers/line_chart_renderer.dart
+++ b/lib/charts/cartesian_renderers/line_chart_renderer.dart
@@ -208,7 +208,7 @@ class LineChartRenderer extends CartesianRendererBase {
       ..style('visibility', 'hidden');
   }
 
-  int _getNearestRowIndex(double x) {
+  int _getNearestRowIndex(num x) {
     var lastSmallerValue = 0;
     var chartX = x - area.layout.renderArea.x;
     for (var i = 0; i < _xPositions.length; i++) {

--- a/lib/charts/src/layout_area_impl.dart
+++ b/lib/charts/src/layout_area_impl.dart
@@ -259,7 +259,9 @@ class DefaultLayoutAreaImpl implements LayoutArea {
     _series = series;
 
     // Updates the legend if required.
-    _config.legend.update(legend, this);
+    if (_config.legend != null) {
+      _config.legend.update(legend, this);
+    }
   }
 
   @override


### PR DESCRIPTION
…y function

  to use num instead of double, this was getting an error because the coordinate
  returned by the event is not double.
- Added a null check on legend for the layout_area_impl before calling update.