### PR TITLE
Fix serious bug in color utils.

### DIFF
--- a/lib/core/utils/color.dart
+++ b/lib/core/utils/color.dart
@@ -281,7 +281,7 @@ class Color {
         rgb = (rgb * 16 + val) * 16 + val;
       }
     } else if (hex.length == 6) {
-      rgb = int.parse(in hex, radix: 16);
+      rgb = int.parse(hex, radix: 16);
     }
 
     return new Color.fromRgba(

--- a/lib/core/utils/color.dart
+++ b/lib/core/utils/color.dart
@@ -276,12 +276,12 @@ class Color {
 
     hex = hex.substring(1);
     if (hex.length == 3) {
-      for (final char in hex) {
-        final val = int.parse(char, radix: 16);
+      for (int i = 0; i < hex.length; i++) {
+        final val = int.parse(hex[i], radix: 16);
         rgb = (rgb * 16 + val) * 16 + val;
       }
     } else if (hex.length == 6) {
-      rgb = int.parse(hex, radix: 16);
+      rgb = int.parse(in hex, radix: 16);
     }
 
     return new Color.fromRgba(


### PR DESCRIPTION
While compiling the Dart VM for ARMv6, Observatory gave this warning:

```
[Warning from Dart2JS on observatory|web/index.html.polymer.bootstrap.dart]:
packages/charted/core/utils/color.dart:279:26:
No member named 'iterator' in class 'String'.
      for (final char in hex) {
```

There was a bug in dart2js that allowed this code to work. In Dart v1.15 it is fixed. At the time of making this PR, v1.15 is not stable yet.

See https://github.com/dart-lang/sdk/commit/d8467b7e2d4d06ee61efd240fd549943ab3821c5 for the fix in dart2js that will break this code.