### PR TITLE
Change the call disposer.dipose for line chart renderer before the null

### DIFF
--- a/lib/charts/cartesian_renderers/line_chart_renderer.dart
+++ b/lib/charts/cartesian_renderers/line_chart_renderer.dart
@@ -115,10 +115,10 @@ class LineChartRenderer extends CartesianRendererBase {
 
   @override
   void dispose() {
+    _disposer.dispose();
     if (root == null) return;
     root.selectAll('.line-rdr-line').remove();
     root.selectAll('.line-rdr-point').remove();
-    _disposer.dispose();
   }
 
   @override
@@ -201,9 +201,8 @@ class LineChartRenderer extends CartesianRendererBase {
 
     if (showHoverCardOnTrackedDataPoints) {
       var firstMeasureColumn = series.measures.first;
-      mouseOverController.add(
-          new DefaultChartEventImpl(event.source, area, series, row,
-          firstMeasureColumn, 0));
+      mouseOverController.add(new DefaultChartEventImpl(
+          event.source, area, series, row, firstMeasureColumn, 0));
       _savedOverRow = row;
       _savedOverColumn = firstMeasureColumn;
     }

--- a/lib/charts/src/cartesian_area_impl.dart
+++ b/lib/charts/src/cartesian_area_impl.dart
@@ -321,7 +321,7 @@ class DefaultCartesianAreaImpl implements CartesianArea {
         info.check();
         group.attributes['transform'] = transform;
         (s.renderer as CartesianRenderer)
-            .draw(group, schedulePostRender: schedulePostRender);
+            ?.draw(group, schedulePostRender: schedulePostRender);
       });
 
       // A series that was rendered earlier isn't there anymore, remove it


### PR DESCRIPTION
check for root, as it is possible for the listener to be set up prior to
the root is set.  Add null check for the series renderer prior to draw.