### PR TITLE
fix for new strong mode inference algorithm

### DIFF
--- a/examples/layout/treemap_demo.dart
+++ b/examples/layout/treemap_demo.dart
@@ -59,8 +59,8 @@ main() {
     node.enter.append("div")
       ..styleWithCallback('left', (d, i, e) => '${d.x}px')
       ..styleWithCallback('top', (d, i, e) => '${d.y}px')
-      ..styleWithCallback('width', (d, i, e) => '${max(0, d.dx - 1)}px')
-      ..styleWithCallback('height', (d, i, e) => '${max(0, d.dy - 1)}px')
+      ..styleWithCallback('width', (d, i, e) => '${max(0, (d.dx as int) - 1)}px')
+      ..styleWithCallback('height', (d, i, e) => '${max(0, (d.dy as int) - 1)}px')
       ..styleWithCallback('background', (d, i, e) => d.children.isNotEmpty ?
           theme.getColorForKey(d.label, ChartTheme.STATE_NORMAL) : null)
       ..textWithCallback((d, i, e) => d.children.isNotEmpty ? null : d.label)

--- a/lib/core/utils/lists.dart
+++ b/lib/core/utils/lists.dart
@@ -16,12 +16,12 @@ num sum(List values) => values == null || values.isEmpty
 /// Returns the smallest number in the given list of values
 num min(Iterable values) => values == null || values.isEmpty
     ? null
-    : values.fold(values.elementAt(0) as num, math.min);
+    : values.fold(values.elementAt(0) as num, (x, y) => math.min(x, y));
 
 /// Returns the largest number in the given list of values
 num max(Iterable values) => values == null || values.isEmpty
     ? null
-    : values.fold(values.elementAt(0) as num, math.max);
+    : values.fold(values.elementAt(0) as num, (x, y) => math.min(x, y));
 
 /// Represents a constant pair of values
 class Pair<T1, T2> {

--- a/lib/core/utils/lists.dart
+++ b/lib/core/utils/lists.dart
@@ -21,7 +21,7 @@ num min(Iterable values) => values == null || values.isEmpty
 /// Returns the largest number in the given list of values
 num max(Iterable values) => values == null || values.isEmpty
     ? null
-    : values.fold(values.elementAt(0) as num, (x, y) => math.min(x, y));
+    : values.fold(values.elementAt(0) as num, (x, y) => math.max(x, y));
 
 /// Represents a constant pair of values
 class Pair<T1, T2> {


### PR DESCRIPTION
Fixes a few types to help this code work in Strong Mode.

Note, for `num min(Iterable values)` and max, it would also be possible to fix it with `num min(Iterable<num> values)`, which would reduce the amount of runtime casts required. However that would no longer allow `Iterable<dynamic>` to be passed (in strong mode). Let me know if you would prefer `Iterable<num> values` approach. Thanks!