### PR TITLE
Various bug fixes to prevent errors

### DIFF
--- a/lib/charts/src/cartesian_area_impl.dart
+++ b/lib/charts/src/cartesian_area_impl.dart
@@ -136,6 +136,9 @@ class DefaultCartesianAreaImpl implements CartesianArea {
       _chartAxesUpdatedController.close();
       _chartAxesUpdatedController = null;
     }
+    if (_behaviors.isNotEmpty) {
+      _behaviors.forEach((behavior) => behavior.dispose());
+    }
   }
 
   static bool isNotInline(Element e) =>

--- a/lib/core/text_metrics.dart
+++ b/lib/core/text_metrics.dart
@@ -100,6 +100,7 @@ class TextMetrics {
           min = mid + 1;
         }
       }
+      if (max < 0) max = 0;
       text = text.substring(0, indices[max]) + '…';
     }
     return text;

--- a/lib/locale/format/number_format.dart
+++ b/lib/locale/format/number_format.dart
@@ -141,6 +141,7 @@ class NumberFormat {
     var zcomma = (zfill != null) && comma;
 
     return (value) {
+      if (value == null) return '-';
       var fullSuffix = suffix;
 
       // Return the empty string for floats formatted as ints.


### PR DESCRIPTION
- Dispose registered behaviors when chart area disposes.
- When null is passed into number format, return '-' instead of error
out.
- When ellipsed String index computes to be less than 0, use 0.