### PR TITLE
Change the definition of chart's outter padding.

### DIFF
--- a/lib/charts/chart_theme.dart
+++ b/lib/charts/chart_theme.dart
@@ -84,7 +84,7 @@ abstract class ChartAxisTheme {
   /// Space between axis and label for dimension axes
   int get axisTickPadding;
 
-  /// Space between the first tick and the measure axes in pixel.
+  /// Space between the first tick and the measure axes in pixels.
   /// Only used on charts that don't have renderers that use "bands" of space
   /// on the dimension axes
   double get axisOuterPadding;
@@ -97,7 +97,7 @@ abstract class ChartAxisTheme {
   /// space between two consecutive ticks is also known as the segment size.
   double get axisBandInnerPadding;
 
-  /// Space between the first band and the measure axis  in pixel.
+  /// Space between the first band and the measure axis in pixels.
   /// Only used on charts that have renderers that use "bands" of space on the
   /// dimension axes.
   double get axisBandOuterPadding;

--- a/lib/charts/chart_theme.dart
+++ b/lib/charts/chart_theme.dart
@@ -84,12 +84,9 @@ abstract class ChartAxisTheme {
   /// Space between axis and label for dimension axes
   int get axisTickPadding;
 
-  /// Space between the first tick and the measure axes.
+  /// Space between the first tick and the measure axes in pixel.
   /// Only used on charts that don't have renderers that use "bands" of space
   /// on the dimension axes
-  ///
-  /// Represented as a percentage of space between two consecutive ticks. The
-  /// space between two consecutive ticks is also known as the segment size.
   double get axisOuterPadding;
 
   /// Space between the two bands in the chart.
@@ -100,12 +97,9 @@ abstract class ChartAxisTheme {
   /// space between two consecutive ticks is also known as the segment size.
   double get axisBandInnerPadding;
 
-  /// Space between the first band and the measure axis.
+  /// Space between the first band and the measure axis  in pixel.
   /// Only used on charts that have renderers that use "bands" of space on the
   /// dimension axes.
-  ///
-  /// Represented as a percentage of space between two consecutive ticks. The
-  /// space between two consecutive ticks is also known as the segment size.
   double get axisBandOuterPadding;
 
   /// When set to true, the vertical axes resize to fit the labels.

--- a/lib/charts/themes/quantum_theme.dart
+++ b/lib/charts/themes/quantum_theme.dart
@@ -146,9 +146,9 @@ class QuantumChartAxisTheme implements ChartAxisTheme {
   final String ticksFont;
 
   QuantumChartAxisTheme(this.axisTickSize, this.axisTickCount,
-      {this.axisOuterPadding: 0.1,
+      {this.axisOuterPadding: 12.0,
       this.axisBandInnerPadding: 0.35,
-      this.axisBandOuterPadding: 0.175,
+      this.axisBandOuterPadding: 12.0,
       this.axisTickPadding: 6,
       this.verticalAxisAutoResize: true,
       this.verticalAxisWidth: 75,

--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -120,11 +120,10 @@ class _OrdinalScale implements OrdinalScale {
     scale._reset = (_OrdinalScale s) {
       var start = range.first,
           stop = range.last,
-          step = (stop - start) / (s.domain.length - 1 + padding);
+          step = (stop - start - 2 * padding) / (s.domain.length);
 
       s._range = s._steps(
-          s.domain.length < 2 ? (start + stop) / 2 : start + step * padding / 2,
-          step);
+          s.domain.length < 2 ? (start + stop) / 2 : start + padding, step);
       s._rangeBand = 0;
       s._rangeExtent = new Extent(start, stop);
     };
@@ -138,7 +137,7 @@ class _OrdinalScale implements OrdinalScale {
     scale._reset = (_OrdinalScale s) {
       var start = range.first,
           stop = range.last,
-          step = (stop - start) / s.domain.length - padding + 2 * outerPadding;
+          step = (stop - start - 2 * outerPadding) / (s.domain.length - padding);
 
       s._range = s._steps(start + step * outerPadding, step);
       s._rangeBand = step * (1 - padding);
@@ -155,11 +154,10 @@ class _OrdinalScale implements OrdinalScale {
       var start = range.first,
           stop = range.last,
           step =
-          ((stop - start) / (s.domain.length - padding + 2 * outerPadding))
-              .floor(),
-          error = stop - start - (s.domain.length - padding) * step;
+          ((stop - start - 2 * outerPadding) / (s.domain.length - padding))
+              .floor();
 
-      s._range = s._steps(start + (error / 2).round(), step);
+      s._range = s._steps(start + outerPadding, step);
       s._rangeBand = (step * (1 - padding)).round();
       s._rangeExtent = new Extent(start, stop);
     };


### PR DESCRIPTION
- It is undesirable for chart's outter padding to be based on the step size between
ticks.
  * The original behavior make the first tick on the ordinal scale to
position itself base on the number of elements in the domain.
  * This situation is especially bad when there is a large number of
elements in the domain, the outter padding becomes unreasonably large
and causing the chart to cram in the middle of the whole chart area,
making the chart very hard to use/read.