### PR TITLE
Handle the case where there's only one row of data

### DIFF
--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -137,7 +137,10 @@ class _OrdinalScale implements OrdinalScale {
     scale._reset = (_OrdinalScale s) {
       var start = range.first,
           stop = range.last,
-          step = (stop - start - 2 * outerPadding) / (s.domain.length - padding);
+          step = (stop - start - 2 * outerPadding) /
+              s.domain.length > 1
+                  ? (s.domain.length - padding)
+                  : 1;
 
       s._range = s._steps(start + step * outerPadding, step);
       s._rangeBand = step * (1 - padding);
@@ -154,8 +157,10 @@ class _OrdinalScale implements OrdinalScale {
       var start = range.first,
           stop = range.last,
           step =
-          ((stop - start - 2 * outerPadding) / (s.domain.length - padding))
-              .floor();
+          ((stop - start - 2 * outerPadding) /
+              s.domain.length > 1
+                  ? (s.domain.length - padding)
+                  : 1).floor();
 
       s._range = s._steps(start + outerPadding, step);
       s._rangeBand = (step * (1 - padding)).round();

--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -138,9 +138,9 @@ class _OrdinalScale implements OrdinalScale {
       var start = range.first,
           stop = range.last,
           step = (stop - start - 2 * outerPadding) /
-              s.domain.length > 1
+              (s.domain.length > 1
                   ? (s.domain.length - padding)
-                  : 1;
+                  : 1);
 
       s._range = s._steps(start + step * outerPadding, step);
       s._rangeBand = step * (1 - padding);
@@ -158,9 +158,9 @@ class _OrdinalScale implements OrdinalScale {
           stop = range.last,
           step =
           ((stop - start - 2 * outerPadding) /
-              s.domain.length > 1
+              (s.domain.length > 1
                   ? (s.domain.length - padding)
-                  : 1).floor();
+                  : 1)).floor();
 
       s._range = s._steps(start + outerPadding, step);
       s._rangeBand = (step * (1 - padding)).round();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: charted
-version: 0.4.3
+version: 0.4.5
 authors:
 - Prasad Sunkari <prsd@google.com>
 - Michael Cheng <midoringo@google.com>


### PR DESCRIPTION
- Currently because of the inner padding is 1.0 the step function will
evaluate to infinity instead of generating the correct step distance.

- Update pubspec for another version.