### PR TITLE
Range point's computation should have domain.length -1 in denominator to

### DIFF
--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -120,7 +120,9 @@ class _OrdinalScale implements OrdinalScale {
     scale._reset = (_OrdinalScale s) {
       var start = range.first,
           stop = range.last,
-          step = (stop - start - 2 * padding) / (s.domain.length - 1);
+          step = s.domain.length > 1
+              ? (stop - start - 2 * padding) / (s.domain.length - 1)
+              : 0;
 
       s._range = s._steps(
           s.domain.length < 2 ? (start + stop) / 2 : start + padding, step);

--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -120,7 +120,7 @@ class _OrdinalScale implements OrdinalScale {
     scale._reset = (_OrdinalScale s) {
       var start = range.first,
           stop = range.last,
-          step = (stop - start - 2 * padding) / (s.domain.length);
+          step = (stop - start - 2 * padding) / (s.domain.length - 1);
 
       s._range = s._steps(
           s.domain.length < 2 ? (start + stop) / 2 : start + padding, step);


### PR DESCRIPTION
create the correct steps for the ticks.