### PR TITLE
Changed the signature for chart data back to interables.  Change the …

### DIFF
--- a/lib/charts/chart_data.dart
+++ b/lib/charts/chart_data.dart
@@ -21,7 +21,7 @@ abstract class ChartData {
 
   /// Create a new instance of [ChartData]'s internal implementation
   factory ChartData(Iterable<ChartColumnSpec> columns,
-      List<List> rows) = DefaultChartDataImpl;
+      Iterable<Iterable> rows) = DefaultChartDataImpl;
 }
 
 ///

--- a/lib/charts/src/chart_data_impl.dart
+++ b/lib/charts/src/chart_data_impl.dart
@@ -16,9 +16,15 @@ class DefaultChartDataImpl extends Observable implements ChartData {
   SubscriptionsDisposer _disposer = new SubscriptionsDisposer();
 
   DefaultChartDataImpl(
-      Iterable<ChartColumnSpec> columns, List<List> rows) {
-    this.columns = columns;
-    this.rows = rows;
+      Iterable<ChartColumnSpec> columns, Iterable<Iterable> rows) {
+    this.columns = new List<ChartColumnSpec>.from(columns);
+    if (rows is List && rows.every((row) => row is List)) {
+      this.rows = rows;
+    } else {
+      var rowsList = new List.from(rows);
+      this.rows = new List<List>.generate(
+          rowsList.length, (i) => new List.from(rowsList[i]));
+    }
   }
 
   set columns(Iterable<ChartColumnSpec> value) {
@@ -86,8 +92,7 @@ class DefaultChartDataImpl extends Observable implements ChartData {
     if (!_hasObservableRows) return;
     notifyChange(new ChartValueChangeRecord(index, changes));
   }
-
-  @override
+  
   String toString() {
     var cellDataLength = new List.filled(rows.elementAt(0).length, 0);
     for (var i = 0; i < columns.length; i++) {

--- a/lib/charts/src/chart_events_impl.dart
+++ b/lib/charts/src/chart_events_impl.dart
@@ -9,7 +9,6 @@
 part of charted.charts;
 
 class DefaultChartEventImpl implements ChartEvent {
-  @override
   final ChartArea area;
 
   @override

--- a/lib/charts/themes/quantum_theme.dart
+++ b/lib/charts/themes/quantum_theme.dart
@@ -137,9 +137,6 @@ class QuantumChartAxisTheme implements ChartAxisTheme {
   final int verticalAxisWidth;
 
   @override
-  final bool horizontalAxisAutoResize;
-
-  @override
   final int horizontalAxisHeight;
 
   @override
@@ -152,7 +149,6 @@ class QuantumChartAxisTheme implements ChartAxisTheme {
       this.axisTickPadding: 6,
       this.verticalAxisAutoResize: true,
       this.verticalAxisWidth: 75,
-      this.horizontalAxisAutoResize: false,
       this.horizontalAxisHeight: 50,
       this.ticksFont: '12px Roboto'});
 }


### PR DESCRIPTION
…constructor to only initialize rows in List only if the provided data is not already in List.

Removed a couple @override annotation for fields/methods that don't actually override.

Removed horizontalAxisAutoResize from QuantumAxisTheme as it no longer exists in the ChartAxisTheme.