### PR TITLE
Migrate generic method comments to real generics

### DIFF
--- a/lib/core/scales.dart
+++ b/lib/core/scales.dart
@@ -120,8 +120,7 @@ class RoundingFunctions extends Pair<RoundFunction, RoundFunction> {
       new RoundingFunctions((x) => x.floor(), (x) => x.ceil());
 
   factory RoundingFunctions.identity() => new RoundingFunctions(
-      (num n) => identityFunction/*<num>*/(n),
-      (num n) => identityFunction/*<num>*/(n));
+      (num n) => identityFunction<num>(n), (num n) => identityFunction<num>(n));
 
   RoundFunction get floor => super.first;
   RoundFunction get ceil => super.last;

--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -95,7 +95,7 @@ class _OrdinalScale implements OrdinalScale {
 
   @override
   FormatFunction createTickFormatter([String format]) =>
-      (String s) => identityFunction/*<String>*/(s);
+      (String s) => identityFunction<String>(s);
 
   @override
   Iterable get ticks => _domain;

--- a/lib/core/utils.dart
+++ b/lib/core/utils.dart
@@ -32,7 +32,7 @@ const String ORIENTATION_TOP = 'top';
 const String ORIENTATION_BOTTOM = 'bottom';
 
 /// Identity function that returns the value passed as it's parameter.
-/*=T*/ identityFunction/*<T>*/(/*=T*/ x) => x;
+T identityFunction<T>(T x) => x;
 
 /// Function that formats a value to String.
 typedef String FormatFunction(value);

--- a/lib/selection/selection.dart
+++ b/lib/selection/selection.dart
@@ -37,8 +37,7 @@ typedef E SelectionCallback<E>(datum, int index, Element element);
 typedef E SelectionValueAccessor<E>(datum, int index);
 
 /** Create a ChartedCallback that always returns [val] */
-SelectionCallback/*<T>*/ toCallback/*<T>*/(/*=T*/ val) =>
-    (datum, index, element) => val;
+SelectionCallback<T> toCallback<T>(T val) => (datum, index, element) => val;
 
 /** Create a ChartedValueAccessor that always returns [val] */
 SelectionValueAccessor toValueAccessor(val) => (datum, index) => val;


### PR DESCRIPTION
The old comment-style generic method syntax will be removed before Dart 2.0. https://github.com/dart-lang/sdk/issues/28796