### PR TITLE
Fix a few uses_dynamic_as_bottom errors around FormatFunction

### DIFF
--- a/lib/core/scales/log_scale.dart
+++ b/lib/core/scales/log_scale.dart
@@ -163,7 +163,8 @@ class LogScale implements Scale {
         formatter.format(formatStr != null ? formatStr : ".0E");
     var k = math.max(.1, ticksCount / this.ticks.length),
         e = _positive ? 1e-12 : -1e-12;
-    return (num d) {
+    return (dynamic _d) {
+      var d = _d as num;
       if (_positive) {
         return d / _pow((_log(d) + e).ceil()) <= k ? logFormatFunction(d) : '';
       } else {

--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -95,7 +95,7 @@ class _OrdinalScale implements OrdinalScale {
 
   @override
   FormatFunction createTickFormatter([String format]) =>
-      (String s) => identityFunction<String>(s as String);
+      (dynamic s) => identityFunction<String>(s as String);
 
   @override
   Iterable get ticks => _domain;

--- a/lib/core/scales/ordinal_scale.dart
+++ b/lib/core/scales/ordinal_scale.dart
@@ -95,7 +95,7 @@ class _OrdinalScale implements OrdinalScale {
 
   @override
   FormatFunction createTickFormatter([String format]) =>
-      (String s) => identityFunction/*<String>*/(s);
+      (dynamic s) => identityFunction/*<String>*/(s as String);
 
   @override
   Iterable get ticks => _domain;

--- a/lib/core/scales/time_scale.dart
+++ b/lib/core/scales/time_scale.dart
@@ -52,7 +52,7 @@ class TimeScale extends LinearScale {
     [TimeInterval.year, 1]
   ];
 
-  static TimeFormatFunction _scaleLocalFormat = new TimeFormat().multi([
+  static FormatFunction _scaleLocalFormat = new TimeFormat().multi([
     [".%L", (DateTime d) => d.millisecond > 0],
     [":%S", (DateTime d) => d.second > 0],
     ["%I:%M", (DateTime d) => d.minute > 0],

--- a/lib/locale/format/number_format.dart
+++ b/lib/locale/format/number_format.dart
@@ -142,7 +142,8 @@ class NumberFormat {
 
     var zcomma = (zfill != null) && comma;
 
-    return (num value) {
+    return (dynamic _value) {
+      var value = _value as num;
       if (value == null) return '-';
       var fullSuffix = suffix;
 

--- a/lib/locale/format/time_format.dart
+++ b/lib/locale/format/time_format.dart
@@ -7,8 +7,6 @@
  */
 part of charted.locale.format;
 
-typedef String TimeFormatFunction(DateTime date);
-
 //TODO(songrenchu): Document time format; Add test for time format.
 
 class TimeFormat {
@@ -39,7 +37,7 @@ class TimeFormat {
     return _dateFormat.parse(string);
   }
 
-  TimeFormatFunction multi(List<List> formats) {
+  FormatFunction multi(List<List> formats) {
     var n = formats.length, i = -1;
     while (++i < n) formats[i][0] = _getInstance(formats[i][0] as String);
     return (var date) {


### PR DESCRIPTION
This PR basically forces every function assigned as a `FormatFunction` to understand that it needs to accept `dynamic` arguments, as the signature of `FormatFunction` is:

```dart
typedef String FormatFunction(value);
```

The alternative to this PR is something far hairier. Specifically, we have the following declarations:


```dart
abstract class Scale {
  FormatFunction createTickFormatter([String format]);
}

class LinearScale implements Scale {
  FormatFunction createTickFormatter([String formatStr]);
}

class TimeScale extends LinearScale {
  // A function of type '(DateTime) → String' can't be assigned to a variable of type '(dynamic) → String'
  FormatFunction createTickFormatter([String format]);
}
```

If we instead want to type annotate FormatFunction as:

```dart
typedef String FormatFunction<T>(T value);
```

Then we'd be able to type annotate `createTickFormatter`, but not in a way that `TimeScale` could still extend `LinearScale`. This would be a much bigger change that I should not author. I suggest we go with this PR, at least for now.