### PR TITLE
Fix dynamic-as-bottom issues with SelectionCallback

### DIFF
--- a/lib/charts/behaviors/chart_tooltip.dart
+++ b/lib/charts/behaviors/chart_tooltip.dart
@@ -121,15 +121,17 @@ class ChartTooltip implements ChartBehavior {
     var tooltipItems = _tooltipRoot.selectAll('.tooltip-item');
     tooltipItems.append('div')
       ..classed('tooltip-item-label')
-      ..textWithCallback((int d, i, c) => _area.data.columns
-          .elementAt((showSelectedMeasure) ? d : e.series.measures.elementAt(i))
+      ..textWithCallback((d, i, c) => _area.data.columns
+          .elementAt(
+              (showSelectedMeasure) ? d as int : e.series.measures.elementAt(i))
           .label);
 
     // Display the value of the currently active series
     tooltipItems.append('div')
       ..classed('tooltip-item-value')
       ..styleWithCallback('color', (d, i, c) => _area.theme.getColorForKey(d))
-      ..textWithCallback((int d, i, c) {
+      ..textWithCallback((_d, i, c) {
+        int d = _d;
         var formatter = _getFormatterForColumn(d),
             value = _area.data.rows.elementAt(e.row).elementAt(d);
         return (formatter != null) ? formatter(value) : value.toString();

--- a/lib/charts/behaviors/line_marker.dart
+++ b/lib/charts/behaviors/line_marker.dart
@@ -95,7 +95,8 @@ class LineMarker implements ChartBehavior {
     if (!_area.isReady) return;
     _markers = _parent.selectAll('.line-marker').data(positions.keys);
 
-    _markers.enter.append('path').each((int d, i, e) {
+    _markers.enter.append('path').each((_d, i, e) {
+      int d = _d;
       e.classes.add('line-marker');
       e.attributes['d'] = _getMarkerPath(d, animate);
     });
@@ -103,7 +104,7 @@ class LineMarker implements ChartBehavior {
     if (animate) {
       _markers
           .transition()
-          .attrWithCallback('d', (int d, i, e) => _getMarkerPath(d, false));
+          .attrWithCallback('d', (d, i, e) => _getMarkerPath(d as int, false));
     }
 
     _markers.exit.remove();

--- a/lib/charts/cartesian_renderers/bar_chart_renderer.dart
+++ b/lib/charts/cartesian_renderers/bar_chart_renderer.dart
@@ -141,7 +141,8 @@ class BarChartRenderer extends CartesianRendererBase {
       }
     };
 
-    bar.enter.appendWithCallback((num d, i, e) {
+    bar.enter.appendWithCallback((_d, i, e) {
+      num d = _d;
       var rect = Namespace.createChildElement('path', e),
           measure = series.measures.elementAt(i),
           row = int.parse(e.dataset['row']),
@@ -168,9 +169,10 @@ class BarChartRenderer extends CartesianRendererBase {
       }
       return rect;
     })
-      ..on('click', (num d, i, e) => _event(mouseClickController, d, i, e))
-      ..on('mouseover', (num d, i, e) => _event(mouseOverController, d, i, e))
-      ..on('mouseout', (num d, i, e) => _event(mouseOutController, d, i, e));
+      ..on('click', (d, i, e) => _event(mouseClickController, d as num, i, e))
+      ..on(
+          'mouseover', (d, i, e) => _event(mouseOverController, d as num, i, e))
+      ..on('mouseout', (d, i, e) => _event(mouseOutController, d as num, i, e));
 
     if (animateBarGroups) {
       bar.each((d, i, e) {
@@ -194,7 +196,7 @@ class BarChartRenderer extends CartesianRendererBase {
       });
 
       bar.transition()
-        ..attrWithCallback('d', (num d, i, e) => buildPath(d, i, false));
+        ..attrWithCallback('d', (d, i, e) => buildPath(d as num, i, false));
     }
 
     bar.exit.remove();

--- a/lib/charts/cartesian_renderers/line_chart_renderer.dart
+++ b/lib/charts/cartesian_renderers/line_chart_renderer.dart
@@ -151,7 +151,8 @@ class LineChartRenderer extends CartesianRendererBase {
     });
 
     linePoints
-      ..each((int d, i, e) {
+      ..each((_d, i, e) {
+        int d = _d;
         var color = colorForColumn(d);
         e.attributes
           ..['r'] = '4'
@@ -174,7 +175,8 @@ class LineChartRenderer extends CartesianRendererBase {
     }
 
     var yScale = area.measureScales(series).first;
-    root.selectAll('.line-rdr-point').each((int d, i, e) {
+    root.selectAll('.line-rdr-point').each((_d, i, e) {
+      int d = _d;
       num x = _xPositions[row],
           measureVal = area.data.rows.elementAt(row).elementAt(d);
       if (measureVal != null && measureVal.isFinite) {

--- a/lib/charts/cartesian_renderers/stackedline_chart_renderer.dart
+++ b/lib/charts/cartesian_renderers/stackedline_chart_renderer.dart
@@ -205,7 +205,8 @@ class StackedLineChartRenderer extends CartesianRendererBase {
     });
 
     linePoints
-      ..each((int d, i, e) {
+      ..each((_d, i, e) {
+        int d = _d;
         var color = colorForColumn(d);
         e.attributes
           ..['r'] = '4'
@@ -229,7 +230,8 @@ class StackedLineChartRenderer extends CartesianRendererBase {
 
     double cumulated = 0.0;
     var yScale = area.measureScales(series).first;
-    root.selectAll('.stacked-line-rdr-point').each((int d, i, e) {
+    root.selectAll('.stacked-line-rdr-point').each((_d, i, e) {
+      int d = _d;
       var x = _xPositions[row],
           measureVal =
               cumulated += area.data.rows.elementAt(row).elementAt(d) as num;

--- a/lib/charts/src/cartesian_area_impl.dart
+++ b/lib/charts/src/cartesian_area_impl.dart
@@ -316,7 +316,8 @@ class DefaultCartesianAreaImpl implements CartesianArea {
       String transform =
           'translate(${layout.renderArea.x},${layout.renderArea.y})';
 
-      selection.each((ChartSeries s, _, Element group) {
+      selection.each((_s, _, Element group) {
+        ChartSeries s = _s;
         _ChartSeriesInfo info = _seriesInfoCache[s];
         if (info == null) {
           info = _seriesInfoCache[s] = new _ChartSeriesInfo(this, s);
@@ -329,7 +330,8 @@ class DefaultCartesianAreaImpl implements CartesianArea {
 
       // A series that was rendered earlier isn't there anymore, remove it
       selection.exit
-        ..each((ChartSeries s, _, __) {
+        ..each((_s, _, __) {
+          ChartSeries s = _s;
           var info = _seriesInfoCache.remove(s);
           if (info != null) {
             info.dispose();
@@ -504,7 +506,8 @@ class DefaultCartesianAreaImpl implements CartesianArea {
           .data(displayedMeasureAxes);
       // Update measure axis (add/remove/update)
       axisGroups.enter.append('svg:g');
-      axisGroups.each((String axisId, index, group) {
+      axisGroups.each((_axisId, index, group) {
+        String axisId = _axisId;
         _getMeasureAxis(axisId).draw(group, _scope, preRender: preRender);
         group.attributes['class'] = 'measure-axis-group measure-${index}';
       });
@@ -518,7 +521,8 @@ class DefaultCartesianAreaImpl implements CartesianArea {
           .data(displayedDimensionAxes);
       // Update dimension axes (add/remove/update)
       dimAxisGroups.enter.append('svg:g');
-      dimAxisGroups.each((int column, index, group) {
+      dimAxisGroups.each((_column, index, group) {
+        int column = _column;
         _getDimensionAxis(column).draw(group, _scope, preRender: preRender);
         group.attributes['class'] = 'dimension-axis-group dim-${index}';
       });

--- a/lib/charts/src/chart_legend_impl.dart
+++ b/lib/charts/src/chart_legend_impl.dart
@@ -115,7 +115,8 @@ class DefaultChartLegendImpl implements ChartLegend {
             .data(_items, (x) => x.hashCode),
         isFirstRender = rows.length == 0;
 
-    var enter = rows.enter.appendWithCallback((ChartLegendItem d, i, e) {
+    var enter = rows.enter.appendWithCallback((_d, i, e) {
+      ChartLegendItem d = _d;
       var row = Namespace.createChildElement('div', e),
           color = Namespace.createChildElement('div', e)
             ..className = 'chart-legend-color',
@@ -159,7 +160,8 @@ class DefaultChartLegendImpl implements ChartLegend {
 
     // We have elements in the DOM that need updating.
     if (!isFirstRender) {
-      rows.each((ChartLegendItem d, i, Element e) {
+      rows.each((_d, i, Element e) {
+        ChartLegendItem d = _d;
         var classes = e.classes;
         if (state != null) {
           if (d.index == state.preview) {
@@ -187,13 +189,15 @@ class DefaultChartLegendImpl implements ChartLegend {
 
     if (state != null) {
       enter
-        ..on('mouseover', (ChartLegendItem d, i, e) => state.preview = d.index)
+        ..on('mouseover',
+            (d, i, e) => state.preview = (d as ChartLegendItem).index)
         ..on('mouseout', (d, i, e) {
           if (state.preview == d.index) {
             state.preview = null;
           }
         })
-        ..on('click', (ChartLegendItem d, i, e) {
+        ..on('click', (_d, i, e) {
+          ChartLegendItem d = _d;
           if (state.isSelected(d.index)) {
             state.unselect(d.index);
           } else {


### PR DESCRIPTION
Here is SelectionCallback:

```dart
typedef E SelectionCallback<E>(datum, int index, Element element);
```

You can see in this PR the many locations where SelectionCallbacks are expected, but functions that take a more specific type for `datum` are used. The repercussions of adding a second type parameter to SelectionCallback are great, so this PR should be used instead.

This is to help eliminate fuzzy arrows. https://github.com/dart-lang/sdk/issues/29630

CC @psunkari 