### PR TITLE
Add voids to support https://github.com/dart-lang/sdk/issues/32161

### DIFF
--- a/lib/svg/axis.dart
+++ b/lib/svg/axis.dart
@@ -63,7 +63,7 @@ class SvgAxis {
   FormatFunction get tickFormat => _tickFormat;
 
   /// Draw an axis on each non-null element in selection
-  draw(Selection g, {SvgAxisTicks axisTicksBuilder, bool isRTL: false}) =>
+  void draw(Selection g, {SvgAxisTicks axisTicksBuilder, bool isRTL: false}) =>
       g.each((d, i, e) =>
           create(e, g.scope, axisTicksBuilder: axisTicksBuilder, isRTL: isRTL));
 


### PR DESCRIPTION
Add void declarations to methods with implicit dynamic returning void
values, which *may* be illegal in dart 2, but in either case, expresses
the current intent better.